### PR TITLE
chore(settings): 移除废弃的歌词渲染器设置入口

### DIFF
--- a/packages/player/locales/en-US/translation.json
+++ b/packages/player/locales/en-US/translation.json
@@ -234,14 +234,6 @@
 						"tiny": "超小"
 					}
 				},
-				"lyricPlayerImplementation": {
-					"description": "Currently, there are two lyrics rendering implementations:\n- DOM: Implemented using DOM elements, currently the most comprehensive, but with high performance overhead\n- Canvas: Implemented using Canvas, still under development, with excellent performance, but some details still need to be improved",
-					"label": "Implementation of the Lyrics Player",
-					"menu": {
-						"dom": "DOM",
-						"dom-slim": "DOM (Stripped)"
-					}
-				},
 				"lyricWordFadeWidth": {
 					"description": "Adjust the gradient transition width of each word in lyrics, measured in the width of a full width character, with a default value of 0.5.\nIf you want to simulate the effect of Apple Music for Android, you can set it to 1.\nIf you want to simulate the effect of Apple Music for iPad, you can set it to 0.5.\nTo turn off the gradient transition effect of each word in lyrics, you can set it to 0.",
 					"label": "Gradient Transition Width of Each Word"

--- a/packages/player/locales/ja-JP/translation.json
+++ b/packages/player/locales/ja-JP/translation.json
@@ -234,14 +234,6 @@
 						"tiny": "超小"
 					}
 				},
-				"lyricPlayerImplementation": {
-					"description": "目前有两个歌词播放实现\n- DOM：使用 DOM 元素实现，目前效果最全，但性能开销大\n- Canvas：使用 Canvas 实现，仍在开发中，性能优异，但是部分细节效果不足",
-					"label": "歌词播放器实现",
-					"menu": {
-						"dom": "DOM",
-						"dom-slim": "DOM（阉割版）"
-					}
-				},
 				"lyricWordFadeWidth": {
 					"description": "调节逐词歌词时单词的渐变过渡宽度，单位为一个全角字的宽度，默认为 0.5。\n如果要模拟 Apple Music for Android 的效果，可以设置为 1。\n如果要模拟 Apple Music for iPad 的效果，可以设置为 0.5。\n如需关闭逐词歌词时单词的渐变过渡效果，可以设置为 0。",
 					"label": "逐词渐变宽度"

--- a/packages/player/locales/vi-VN/translation.json
+++ b/packages/player/locales/vi-VN/translation.json
@@ -234,14 +234,6 @@
 						"tiny": "超小"
 					}
 				},
-				"lyricPlayerImplementation": {
-					"description": "Hiện tại có hai phương pháp phát lời bài hát:\n    DOM: Sử dụng phần tử DOM, hiệu ứng hiện tại là tốt nhất, nhưng hiệu năng tiêu thụ cao.\n    Canvas: Sử dụng Canvas, vẫn đang trong quá trình phát triển, tối ưu hóa hiệu năng, nhưng một số hiệu ứng chi tiết chưa hoàn thiện.",
-					"label": "Triển khai trình phát lời bài hát",
-					"menu": {
-						"dom": "DOM",
-						"dom-slim": "DOM（阉割版）"
-					}
-				},
 				"lyricWordFadeWidth": {
 					"description": "Điều chỉnh độ rộng chuyển đổi dần dần cho từng từ trong lời bài hát, đơn vị là chiều rộng của một ký tự, mặc định là 0.5.\nNếu muốn mô phỏng hiệu ứng của Apple Music cho Android, có thể đặt là 1.\nNếu muốn mô phỏng hiệu ứng của Apple Music cho iPad, có thể đặt là 0.5.\nNếu muốn vô hiệu hóa độ rộng chuyển đổi dần dần cho lời bài hát, có thể đặt là 0.",
 					"label": "Điều chỉnh độ rộng của hiệu ứng làm mờ dần cho từng từ trong lời bài hát"

--- a/packages/player/locales/zh-CN/translation.json
+++ b/packages/player/locales/zh-CN/translation.json
@@ -234,14 +234,6 @@
 						"tiny": "超小"
 					}
 				},
-				"lyricPlayerImplementation": {
-					"description": "目前有两个歌词播放实现\n- DOM：使用 DOM 元素实现，目前效果最全，但性能开销大\n- Canvas：使用 Canvas 实现，仍在开发中，性能优异，但是部分细节效果不足",
-					"label": "歌词播放器实现",
-					"menu": {
-						"dom": "DOM",
-						"dom-slim": "DOM（阉割版）"
-					}
-				},
 				"lyricWordFadeWidth": {
 					"description": "调节逐词歌词时单词的渐变过渡宽度，单位为一个全角字的宽度，默认为 0.5。\n如果要模拟 Apple Music for Android 的效果，可以设置为 1。\n如果要模拟 Apple Music for iPad 的效果，可以设置为 0.5。\n如需关闭逐词歌词时单词的渐变过渡效果，可以设置为 0。",
 					"label": "逐词渐变宽度"

--- a/packages/player/locales/zh-TW/translation.json
+++ b/packages/player/locales/zh-TW/translation.json
@@ -234,14 +234,6 @@
 						"tiny": "超小"
 					}
 				},
-				"lyricPlayerImplementation": {
-					"description": "目前有兩個歌詞播放實現\n- DOM：使用 DOM 元素實現，目前效果最全，但效能開銷大\n- Canvas：使用 Canvas 實現，仍在開發中，性能優異，但部分細節效果不足",
-					"label": "歌詞播放器實現",
-					"menu": {
-						"dom": "DOM",
-						"dom-slim": "DOM（閹割版）"
-					}
-				},
 				"lyricWordFadeWidth": {
 					"description": "調節逐詞歌詞時單字的漸變過渡寬度，單位為全角字的寬度，預設為 0.5。\n如果要模擬 Apple Music for Android 的效果，可以設定為 1。\n如果要模擬 Apple Music for iPad 的效果，可以設定為 0.5。\n如需關閉逐詞歌詞時單字的漸變過渡效果，可設定為 0。",
 					"label": "逐漸漸變寬度"

--- a/packages/player/src/pages/settings/player.tsx
+++ b/packages/player/src/pages/settings/player.tsx
@@ -1,7 +1,5 @@
 import { branch, commit } from "virtual:git-metadata-plugin";
 import {
-	DomLyricPlayer,
-	DomSlimLyricPlayer,
 	MeshGradientRenderer,
 	PixiRenderer,
 } from "@applemusic-like-lyrics/core";
@@ -15,8 +13,6 @@ import {
 	enableLyricTranslationLineAtom,
 	fftDataRangeAtom,
 	type LyricBackgroundRenderer,
-	LyricPlayerImplementation,
-	type LyricPlayerImplementationObject,
 	LyricSizePreset,
 	lyricBackgroundFPSAtom,
 	lyricBackgroundRendererAtom,
@@ -25,7 +21,6 @@ import {
 	lyricFontFamilyAtom,
 	lyricFontWeightAtom,
 	lyricLetterSpacingAtom,
-	lyricPlayerImplementationAtom,
 	lyricSizePresetAtom,
 	lyricWordFadeWidthAtom,
 	PlayerControlsType,
@@ -498,56 +493,6 @@ const LyricContentSettings = () => {
 
 const LyricAppearanceSettings = () => {
 	const { t } = useTranslation();
-	const [lyricPlayerImplValue, setLyricPlayerImplValue] = useAtom(
-		lyricPlayerImplementationAtom,
-	);
-	const lyricPlayerImplementationMenu = useMemo(
-		() => [
-			{
-				label: t(
-					"page.settings.lyricAppearance.lyricPlayerImplementation.menu.dom",
-					"DOM",
-				),
-				value: LyricPlayerImplementation.Dom,
-			},
-			{
-				label: t(
-					"page.settings.lyricAppearance.lyricPlayerImplementation.menu.dom-slim",
-					"DOM（阉割版）",
-				),
-				value: LyricPlayerImplementation.DomSlim,
-			},
-		],
-		[t],
-	);
-
-	const getLyricPlayerString = (
-		value: LyricPlayerImplementationObject,
-	): string => {
-		if (!value?.lyricPlayer) return LyricPlayerImplementation.Dom;
-		if (value.lyricPlayer === DomLyricPlayer)
-			return LyricPlayerImplementation.Dom;
-		if (value.lyricPlayer === DomSlimLyricPlayer)
-			return LyricPlayerImplementation.DomSlim;
-		return LyricPlayerImplementation.Dom;
-	};
-
-	const handleLyricPlayerChange = (selectedString: string) => {
-		let implementationObject: LyricPlayerImplementationObject;
-		switch (selectedString) {
-			case LyricPlayerImplementation.DomSlim:
-				implementationObject = { lyricPlayer: DomSlimLyricPlayer };
-				break;
-			default:
-				implementationObject = { lyricPlayer: DomLyricPlayer };
-				break;
-		}
-		setLyricPlayerImplValue(implementationObject);
-		localStorage.setItem(
-			"amll-react-full.lyricPlayerImplementation",
-			selectedString,
-		);
-	};
 	const [lyricSize, setLyricSize] = useAtom(lyricSizePresetAtom);
 
 	const lyricSizeMenu = useMemo(
@@ -610,30 +555,6 @@ const LyricAppearanceSettings = () => {
 			<SubTitle>
 				<Trans i18nKey="page.settings.lyricAppearance.subtitle">歌词样式</Trans>
 			</SubTitle>
-			<SettingEntry
-				label={t(
-					"page.settings.lyricAppearance.lyricPlayerImplementation.label",
-					"歌词播放器实现",
-				)}
-				description={t(
-					"page.settings.lyricAppearance.lyricPlayerImplementation.description",
-					"目前有两个歌词播放实现\n- DOM：使用 DOM 元素实现，目前效果最全，但性能开销大\n- Canvas：使用 Canvas 实现，仍在开发中，性能优异，但是部分细节效果不足",
-				)}
-			>
-				<Select.Root
-					value={getLyricPlayerString(lyricPlayerImplValue)}
-					onValueChange={handleLyricPlayerChange}
-				>
-					<Select.Trigger />
-					<Select.Content>
-						{lyricPlayerImplementationMenu.map((item) => (
-							<Select.Item key={item.value} value={item.value}>
-								{item.label}
-							</Select.Item>
-						))}
-					</Select.Content>
-				</Select.Root>
-			</SettingEntry>
 			<LyricFontSetting />
 			<SettingEntry
 				label={t(


### PR DESCRIPTION
## 变更说明

上游 `@applemusic-like-lyrics/react-full` 已移除歌词 Canvas 渲染器实现，本次清理播放器设置页中遗留的“歌词播放器实现”入口及对应本地化文案。

## 主要改动

- 删除“歌词样式”里的歌词播放器实现下拉项
- 移除相关 `DomLyricPlayer` / `DomSlimLyricPlayer` 调用和本地存储写入
- 删除 5 个语言包中的 `lyricPlayerImplementation` 文案
- 保留歌词背景渲染器相关设置，不影响 `MeshGradientRenderer` / `PixiRenderer`

## 移除后的设置截图
<img width="640" height="382" alt="image" src="https://github.com/user-attachments/assets/1b9e8910-7fd7-4ce9-89ea-62010cff2e85" />
