### PR TITLE
feat(macos): 解锁 macOS 高帧率限制

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,6 +106,7 @@ dependencies = [
  "tauri-plugin-fs",
  "tauri-plugin-global-shortcut",
  "tauri-plugin-http",
+ "tauri-plugin-macos-fps",
  "tauri-plugin-opener",
  "tauri-plugin-os",
  "tauri-plugin-shell",
@@ -5586,6 +5587,19 @@ dependencies = [
  "tokio",
  "url",
  "urlpattern",
+]
+
+[[package]]
+name = "tauri-plugin-macos-fps"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11177f7c97f1322fbcb5d966ebb0378e411145d65f3f2a2f897d8389ebdba583"
+dependencies = [
+ "log",
+ "objc2",
+ "objc2-foundation",
+ "serde",
+ "tauri",
 ]
 
 [[package]]

--- a/packages/player/src-tauri/Cargo.toml
+++ b/packages/player/src-tauri/Cargo.toml
@@ -73,6 +73,7 @@ webpki-roots = "0.26"
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "^0.6"
 objc2-avf-audio = "^0.3"
+tauri-plugin-macos-fps = "0.1.0"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 webview2-com = "0.38"

--- a/packages/player/src-tauri/src/lib.rs
+++ b/packages/player/src-tauri/src/lib.rs
@@ -457,6 +457,9 @@ pub fn run() {
 
     let builder = tauri::Builder::default().plugin(tauri_plugin_opener::init());
 
+    #[cfg(target_os = "macos")]
+    let builder = builder.plugin(tauri_plugin_macos_fps::init());
+
     #[cfg(not(mobile))]
     let pubkey = {
         if let Some(Value::Object(updater_config)) = context.config().plugins.0.get("updater") {

--- a/packages/player/src-tauri/tauri.conf.json
+++ b/packages/player/src-tauri/tauri.conf.json
@@ -32,6 +32,7 @@
 	"version": "0.0.1",
 	"identifier": "net.stevexmh.amllplayer",
 	"plugins": {
+		"macos-fps": {},
 		"updater": {
 			"pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDVBMzY2M0I2Qjc4MjBBNTUKUldSVkNvSzN0bU0yV2k0bUhxcm9jczBNYk9lTllYaTFyWHVEZ2xaSloxaVhpSnQ1RHZFSUtnS2IK",
 			"endpoints": [


### PR DESCRIPTION
> [!Caution]
> 引入了一项处理私有 API 的库，（如果）上架 App Store 可能需要清除这部分内容。

- 通过引入 [tauri-plugin-macos-fps](https://github.com/userFRM/tauri-plugin-macos-fps) 库修改`PreferPageRenderingUpdatesNear60FPSEnabled` 的值为false；
- 仅 macOS 13 - 15 需要，macOS 26 的 WKWebview 已解除上述限制；
- [构建](https://github.com/ITManCHINA/amll-player/actions/runs/26201004536) 无报错，实测帧率解锁在 macOS 15 可用。