### PR TITLE
fix(build): 修复多处 CI 构建 Warning

### DIFF
--- a/packages/player-core/src/media_state/macos.rs
+++ b/packages/player-core/src/media_state/macos.rs
@@ -1,7 +1,7 @@
 use std::{
     cell::Cell,
     ptr::NonNull,
-    sync::{Mutex, RwLock},
+    sync::Mutex,
 };
 
 use super::*;
@@ -19,6 +19,7 @@ pub struct MediaStateManagerMacOSBackend {
     cmd_ctr: Retained<MPRemoteCommandCenter>,
     info: Mutex<Retained<NSMutableDictionary<NSString, AnyObject>>>,
     playing: Cell<bool>,
+    #[allow(dead_code)]
     sender: UnboundedSender<MediaStateMessage>,
 }
 
@@ -221,7 +222,7 @@ impl MediaStateManagerBackend for MediaStateManagerMacOSBackend {
         let cover_data = NSData::from_vec(cover_data);
         let img = NSImage::alloc();
         let img = NSImage::initWithData(img, &cover_data).context("initWithData")?;
-        let img_size = unsafe { img.size() };
+        let img_size = img.size();
         let img = NonNull::new(Retained::into_raw(img)).unwrap();
         let artwork = MPMediaItemArtwork::alloc();
         let req_handler = block2::RcBlock::new(move |_: NSSize| img);

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -61,6 +61,7 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "catalog:",
+		"@rolldown/plugin-babel": "^0.2.3",
 		"@tauri-apps/cli": "^2.11.1",
 		"@types/convert-source-map": "^2.0.3",
 		"@types/react": "catalog:",
@@ -72,7 +73,6 @@
 		"i18next-cli": "^1.56.11",
 		"jotai-babel": "^0.1.0",
 		"vite": "catalog:",
-		"vite-plugin-babel": "catalog:",
 		"vite-plugin-i18next-loader": "^3.1.3"
 	}
 }

--- a/packages/player/src-tauri/src/lib.rs
+++ b/packages/player/src-tauri/src/lib.rs
@@ -73,20 +73,13 @@ fn restart_app<R: Runtime>(app: AppHandle<R>) {
     tauri::process::restart(&app.env())
 }
 
+#[cfg(target_os = "windows")]
 #[tauri::command]
 fn set_window_always_on_top<R: Runtime>(enabled: bool, app: AppHandle<R>) -> Result<(), String> {
-    #[cfg(target_os = "windows")]
-    {
-        if let Some(window) = app.get_webview_window("main") {
-            window.set_always_on_top(enabled).map_err(|e| e.to_string())
-        } else {
-            Err("Main window not found.".to_string())
-        }
-    }
-    #[cfg(not(target_os = "windows"))]
-    {
-        let _ = (enabled, app);
-        Err("Unsupported on this platform.".to_string())
+    if let Some(window) = app.get_webview_window("main") {
+        window.set_always_on_top(enabled).map_err(|e| e.to_string())
+    } else {
+        Err("Main window not found.".to_string())
     }
 }
 
@@ -588,11 +581,11 @@ pub fn run() {
             }
             Ok(())
         })
-        .on_window_event(|window, event| {
+        .on_window_event(|_window, _event| {
             #[cfg(target_os = "windows")]
-            if let tauri::WindowEvent::Destroyed = event
-                && window.label() == "main"
-                && let Some(taskbar_win) = window.app_handle().get_webview_window("taskbar-lyric")
+            if let tauri::WindowEvent::Destroyed = _event
+                && _window.label() == "main"
+                && let Some(taskbar_win) = _window.app_handle().get_webview_window("taskbar-lyric")
             {
                 let _ = taskbar_win.destroy();
             }

--- a/packages/player/src-tauri/src/lib.rs
+++ b/packages/player/src-tauri/src/lib.rs
@@ -12,11 +12,14 @@ use amll_player_core::AudioInfo;
 use anyhow::Context;
 use ffmpeg_next as ffmpeg;
 use serde::*;
+#[cfg(not(mobile))]
 use serde_json::Value;
 use tauri::{
-    AppHandle, Manager, PhysicalSize, Runtime, Size, State, WebviewWindowBuilder, ipc::Channel,
-    path::BaseDirectory, utils::config::WindowEffectsConfig, window::Effect,
+    AppHandle, Manager, Runtime, State, WebviewWindowBuilder, ipc::Channel,
+    path::BaseDirectory,
 };
+#[cfg(desktop)]
+use tauri::{PhysicalSize, Size, utils::config::WindowEffectsConfig, window::Effect};
 use tokio::sync::RwLock;
 use tracing::*;
 
@@ -300,6 +303,8 @@ async fn recreate_window(app: &AppHandle, label: &str, path: Option<&str>) {
             let _ = win.show();
             let _ = win.set_focus();
         }
+        #[cfg(not(desktop))]
+        let _ = win;
         return;
     }
     #[cfg(debug_assertions)]
@@ -328,6 +333,8 @@ async fn recreate_window(app: &AppHandle, label: &str, path: Option<&str>) {
             let _ = win.set_size(orig_size);
         }
     }
+    #[cfg(not(desktop))]
+    let _ = win;
 
     info!("Created window: {}", label);
 }

--- a/packages/player/src-tauri/src/screen_capture.rs
+++ b/packages/player/src-tauri/src/screen_capture.rs
@@ -1,4 +1,5 @@
 use tauri::AppHandle;
+#[cfg(not(mobile))]
 use tauri::Manager;
 
 use anyhow_tauri::IntoTAResult;
@@ -13,6 +14,7 @@ pub async fn take_screenshot(
 ) -> anyhow_tauri::TAResult<String> {
     #[cfg(mobile)]
     {
+        let _ = (app, resize_window, target_width, target_height, recover_size);
         anyhow_tauri::bail!("Screenshot capture is not supported on Android");
     }
     #[cfg(not(mobile))]

--- a/packages/player/src-tauri/src/screen_capture.rs
+++ b/packages/player/src-tauri/src/screen_capture.rs
@@ -134,9 +134,9 @@ pub async fn take_screenshot(
             }
             #[cfg(not(target_os = "windows"))]
             {
-                anyhow_tauri::bail!(
+                Err(anyhow::anyhow!(
                     "Screenshot capture using DevTools is not supported on this platform yet."
-                )
+                ))
             }
         };
 

--- a/packages/player/vite.config.ts
+++ b/packages/player/vite.config.ts
@@ -1,10 +1,10 @@
 import { execSync } from "node:child_process";
 import { resolve } from "node:path";
+import babel from "@rolldown/plugin-babel";
 import react from "@vitejs/plugin-react";
 import jotaiDebugLabel from "jotai-babel/plugin-debug-label";
 import jotaiReactRefresh from "jotai-babel/plugin-react-refresh";
 import { defineConfig, type Plugin } from "vite";
-import babel from "@rolldown/plugin-babel";
 import i18nextLoader from "vite-plugin-i18next-loader";
 import svgr from "vite-plugin-svgr";
 import wasm from "vite-plugin-wasm";
@@ -40,41 +40,47 @@ const GitMetadataPlugin = (): Plugin => {
 	let gitBranch = "";
 	return {
 		name: "git-metadata-plugin",
-		["buildStart"]: async function() {
-			const metadata = {
-				commit: "",
-				branch: "",
-			};
-			if (!gitCommit)
-				try {
-					gitCommit = getCommitHash();
-				} catch (err) {
-					console.warn("警告：获取 Git Commit Hash 失败", err);
-				}
-			if (!gitBranch)
-				try {
-					gitBranch = getBranchName();
-				} catch (err) {
-					console.warn("警告：获取 Git Branch Name 失败", err);
-				}
-			this.emitFile({
-				fileName: "git-metadata.json",
-				name: "git-metadata",
-				source: JSON.stringify(metadata),
-				type: "asset",
-			});
+		buildStart: {
+			async handler() {
+				const metadata = {
+					commit: "",
+					branch: "",
+				};
+				if (!gitCommit)
+					try {
+						gitCommit = getCommitHash();
+					} catch (err) {
+						console.warn("警告：获取 Git Commit Hash 失败", err);
+					}
+				if (!gitBranch)
+					try {
+						gitBranch = getBranchName();
+					} catch (err) {
+						console.warn("警告：获取 Git Branch Name 失败", err);
+					}
+				this.emitFile({
+					fileName: "git-metadata.json",
+					name: "git-metadata",
+					source: JSON.stringify(metadata),
+					type: "asset",
+				});
+			},
 		},
-		resolveId(id) {
-			if (id === VIRTUAL_ID) {
-				return RESOLVED_VIRTUAL_ID;
-			}
+		resolveId: {
+			handler(id) {
+				if (id === VIRTUAL_ID) {
+					return RESOLVED_VIRTUAL_ID;
+				}
+			},
 		},
-		load(id) {
-			if (id === RESOLVED_VIRTUAL_ID) {
-				return `export const commit = ${JSON.stringify(
-					gitCommit,
-				)};\nexport const branch = ${JSON.stringify(gitBranch)};`;
-			}
+		load: {
+			handler(id) {
+				if (id === RESOLVED_VIRTUAL_ID) {
+					return `export const commit = ${JSON.stringify(
+						gitCommit,
+					)};\nexport const branch = ${JSON.stringify(gitBranch)};`;
+				}
+			},
 		},
 	};
 };

--- a/packages/player/vite.config.ts
+++ b/packages/player/vite.config.ts
@@ -4,7 +4,7 @@ import react from "@vitejs/plugin-react";
 import jotaiDebugLabel from "jotai-babel/plugin-debug-label";
 import jotaiReactRefresh from "jotai-babel/plugin-react-refresh";
 import { defineConfig, type Plugin } from "vite";
-import babel from "vite-plugin-babel";
+import babel from "@rolldown/plugin-babel";
 import i18nextLoader from "vite-plugin-i18next-loader";
 import svgr from "vite-plugin-svgr";
 import wasm from "vite-plugin-wasm";
@@ -40,7 +40,7 @@ const GitMetadataPlugin = (): Plugin => {
 	let gitBranch = "";
 	return {
 		name: "git-metadata-plugin",
-		async buildStart() {
+		["buildStart"]: async function() {
 			const metadata = {
 				commit: "",
 				branch: "",
@@ -82,7 +82,8 @@ const GitMetadataPlugin = (): Plugin => {
 // https://vitejs.dev/config/
 export default defineConfig({
 	build: {
-		rollupOptions: {
+		chunkSizeWarningLimit: 2000,
+		rolldownOptions: {
 			shimMissingExports: true,
 			input: {
 				index: resolve(__dirname, "index.html"),
@@ -94,9 +95,8 @@ export default defineConfig({
 	plugins: [
 		react(),
 		babel({
-			babelConfig: {
-				plugins: [jotaiDebugLabel, jotaiReactRefresh],
-			},
+			plugins: [jotaiDebugLabel, jotaiReactRefresh],
+			include: /\.[jt]sx?$/,
 		}),
 		wasm(),
 		svgr({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,9 +33,6 @@ catalogs:
     vite:
       specifier: ^8.0.11
       version: 8.0.11
-    vite-plugin-babel:
-      specifier: ^1.6.0
-      version: 1.6.0
     vite-plugin-svgr:
       specifier: ^5.2.0
       version: 5.2.0
@@ -195,6 +192,9 @@ importers:
       '@biomejs/biome':
         specifier: 'catalog:'
         version: 2.4.14
+      '@rolldown/plugin-babel':
+        specifier: ^0.2.3
+        version: 0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(rolldown@1.0.0-rc.18)(vite@8.0.11(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.99.0)(yaml@2.8.4))
       '@tauri-apps/cli':
         specifier: ^2.11.1
         version: 2.11.1
@@ -215,7 +215,7 @@ importers:
         version: 0.17.4
       '@vitejs/plugin-react':
         specifier: 'catalog:'
-        version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.11(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.99.0)(yaml@2.8.4))
+        version: 6.0.1(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(rolldown@1.0.0-rc.18)(vite@8.0.11(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.99.0)(yaml@2.8.4)))(babel-plugin-react-compiler@1.0.0)(vite@8.0.11(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.99.0)(yaml@2.8.4))
       '@vitejs/plugin-react-swc':
         specifier: ^4.3.0
         version: 4.3.0(@swc/helpers@0.5.17)(vite@8.0.11(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.99.0)(yaml@2.8.4))
@@ -228,9 +228,6 @@ importers:
       vite:
         specifier: 'catalog:'
         version: 8.0.11(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.99.0)(yaml@2.8.4)
-      vite-plugin-babel:
-        specifier: 'catalog:'
-        version: 1.6.0(@babel/core@7.29.0)(vite@8.0.11(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.99.0)(yaml@2.8.4))
       vite-plugin-i18next-loader:
         specifier: ^3.1.3
         version: 3.1.3(vite@8.0.11(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.99.0)(yaml@2.8.4))
@@ -1748,6 +1745,23 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
+
+  '@rolldown/plugin-babel@0.2.3':
+    resolution: {integrity: sha512-+zEk16yGlz1F9STiRr6uG9hmIXb6nprjLczV/htGptYuLoCuxb+itZ03RKCEeOhBpDDd1NU7qF6x1VLMUp62bw==}
+    engines: {node: '>=22.12.0 || ^24.0.0'}
+    peerDependencies:
+      '@babel/core': ^7.29.0 || ^8.0.0-rc.1
+      '@babel/plugin-transform-runtime': ^7.29.0 || ^8.0.0-rc.1
+      '@babel/runtime': ^7.27.0 || ^8.0.0-rc.1
+      rolldown: ^1.0.0-rc.5
+      vite: ^8.0.0
+    peerDependenciesMeta:
+      '@babel/plugin-transform-runtime':
+        optional: true
+      '@babel/runtime':
+        optional: true
+      vite:
+        optional: true
 
   '@rolldown/pluginutils@1.0.0-rc.18':
     resolution: {integrity: sha512-CUY5Mnhe64xQBGZEEXQ5WyZwsc1JU3vAZLIxtrsBt3LO6UOb+C8GunVKqe9sT8NeWb4lqSaoJtp2xo6GxT1MNw==}
@@ -3390,12 +3404,6 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  vite-plugin-babel@1.6.0:
-    resolution: {integrity: sha512-VtYA4FSmQREA2oaZ7+jfLS/fBk1/xZMUR94YZzB5s6U9WyptbvThUD1HSSv7oNDU28jGuHmdBZ1wTVGNIoChoQ==}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-      vite: ^2.7.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
-
   vite-plugin-i18next-loader@3.1.3:
     resolution: {integrity: sha512-RZCUkQYa9UUq7VlWWq24zqKTR7KjU5TY8ESwHlcfn89Tmbre5QH09DJxB6mFnEp32Y05lePNkzyFm+RSKBEErQ==}
     engines: {node: '>=20'}
@@ -4963,6 +4971,15 @@ snapshots:
   '@rolldown/binding-win32-x64-msvc@1.0.0-rc.18':
     optional: true
 
+  '@rolldown/plugin-babel@0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(rolldown@1.0.0-rc.18)(vite@8.0.11(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.99.0)(yaml@2.8.4))':
+    dependencies:
+      '@babel/core': 7.29.0
+      picomatch: 4.0.4
+      rolldown: 1.0.0-rc.18
+    optionalDependencies:
+      '@babel/runtime': 7.29.2
+      vite: 8.0.11(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.99.0)(yaml@2.8.4)
+
   '@rolldown/pluginutils@1.0.0-rc.18': {}
 
   '@rolldown/pluginutils@1.0.0-rc.7': {}
@@ -5326,11 +5343,12 @@ snapshots:
     transitivePeerDependencies:
       - '@swc/helpers'
 
-  '@vitejs/plugin-react@6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.11(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.99.0)(yaml@2.8.4))':
+  '@vitejs/plugin-react@6.0.1(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(rolldown@1.0.0-rc.18)(vite@8.0.11(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.99.0)(yaml@2.8.4)))(babel-plugin-react-compiler@1.0.0)(vite@8.0.11(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.99.0)(yaml@2.8.4))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
       vite: 8.0.11(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.99.0)(yaml@2.8.4)
     optionalDependencies:
+      '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(rolldown@1.0.0-rc.18)(vite@8.0.11(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.99.0)(yaml@2.8.4))
       babel-plugin-react-compiler: 1.0.0
 
   ansi-escapes@7.1.1:
@@ -6460,11 +6478,6 @@ snapshots:
   use-sync-external-store@1.6.0(react@19.2.6):
     dependencies:
       react: 19.2.6
-
-  vite-plugin-babel@1.6.0(@babel/core@7.29.0)(vite@8.0.11(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.99.0)(yaml@2.8.4)):
-    dependencies:
-      '@babel/core': 7.29.0
-      vite: 8.0.11(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.99.0)(yaml@2.8.4)
 
   vite-plugin-i18next-loader@3.1.3(vite@8.0.11(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.7.0)(sass@1.99.0)(yaml@2.8.4)):
     dependencies:


### PR DESCRIPTION
# refactor: 适配 Vite 8 并消除多端编译警告

更新前端打包配置以适配最新的 Vite 8，并解决多平台编译时溢出的各类 Rust 警告。

### 主要改动
- 更换 `vite-plugin-babel` 为 `@rolldown/plugin-babel` 插件，调大打包限制为 2000，解决 IDE 报错；
- 修复非 Windows 下截图报错引发的“不可达代码”警告。
- 在安卓端通过静默处理隐藏未用形参，既不报警告也不影响前端接口传参。
- 隔离并清理多端编译时多余的库导入、未读字段和无用 `unsafe` 块。
- 本地 `pnpm typecheck` 成功无报错；
- [构建](https://github.com/ITManCHINA/amll-player/actions/runs/26234671058/job/77204559882) 流程已消除 warning 警告。
