### PR TITLE
feat: 支持播放网络音频和加载网络歌曲封面

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,6 +161,7 @@ dependencies = [
  "now-playing-controls",
  "parking_lot",
  "rb",
+ "reqwest 0.13.4",
  "ringbuf",
  "segmap",
  "serde",

--- a/packages/player-core/Cargo.toml
+++ b/packages/player-core/Cargo.toml
@@ -33,6 +33,7 @@ parking_lot = "0.12"
 ffmpeg_audio = { git = "https://github.com/apoint123/ffmpeg-audio.git", rev = "b77e5edea026712c42d58a9dce68e531b812c63f" }
 now-playing-controls = { git = "https://github.com/apoint123/now-playing-controls.git" }
 tokio-util = "0.7.18"
+reqwest = { version = "0.13", default-features = false, features = ["rustls", "stream"] }
 
 [dev-dependencies]
 tracing-subscriber = "0.3"

--- a/packages/player-core/src/player.rs
+++ b/packages/player-core/src/player.rs
@@ -1,7 +1,7 @@
 use std::{
     fmt::Debug,
     fs::File,
-    io::{Read, Seek},
+    io::{Cursor, Read, Seek},
     sync::{
         Arc,
         atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering},
@@ -454,9 +454,20 @@ impl AudioPlayer {
 
         let song_data = self.current_song.clone().context("没有当前歌曲可播放")?;
 
-        let file = File::open(&song_data.file_path)
-            .with_context(|| format!("打开 {} 失败", song_data.file_path))?;
-        let source_stream: Box<dyn CustomMediaSource> = Box::new(file);
+        let source_stream: Box<dyn CustomMediaSource> =
+            if song_data.file_path.starts_with("http://") || song_data.file_path.starts_with("https://") {
+                let bytes = reqwest::get(&song_data.file_path)
+                    .await
+                    .with_context(|| format!("下载 {} 失败", song_data.file_path))?
+                    .bytes()
+                    .await
+                    .with_context(|| format!("读取 {} 响应失败", song_data.file_path))?;
+                Box::new(Cursor::new(bytes.to_vec()))
+            } else {
+                let file = File::open(&song_data.file_path)
+                    .with_context(|| format!("打开 {} 失败", song_data.file_path))?;
+                Box::new(file)
+            };
 
         let target_channels = self.target_channels;
         let target_sample_rate = self.target_sample_rate;

--- a/packages/player/src/components/LocalMusicContext/index.tsx
+++ b/packages/player/src/components/LocalMusicContext/index.tsx
@@ -291,10 +291,15 @@ export const LocalMusicContext: FC = () => {
 				);
 
 				if (songFromDb.coverPath) {
-					store.set(musicCoverAtom, convertFileSrc(songFromDb.coverPath));
+					const coverPath = songFromDb.coverPath;
+					if (coverPath.startsWith("http://") || coverPath.startsWith("https://")) {
+						store.set(musicCoverAtom, coverPath);
+					} else {
+						store.set(musicCoverAtom, convertFileSrc(coverPath));
+					}
 					store.set(
 						musicCoverIsVideoAtom,
-						songFromDb.coverPath.endsWith(".mp4"),
+						coverPath.endsWith(".mp4"),
 					);
 				} else {
 					store.set(

--- a/packages/player/src/components/NowPlaylistCard/index.tsx
+++ b/packages/player/src/components/NowPlaylistCard/index.tsx
@@ -22,7 +22,11 @@ const PlaylistSongItem: FC<
 	const playlistIndex = useAtomValue(queueCurrentIndexAtom);
 	const queueManager = useAtomValue(queueManagerAtom);
 
-	const cover = song.coverPath ? convertFileSrc(song.coverPath) : "";
+	const cover = song.coverPath 
+		? (song.coverPath.startsWith("http://") || song.coverPath.startsWith("https://") 
+			? song.coverPath 
+			: convertFileSrc(song.coverPath))
+		: "";
 	const name = song.songName || "未知歌曲";
 	const artists = song.songArtists || "未知艺术家";
 

--- a/packages/player/src/components/PlaylistCover/index.tsx
+++ b/packages/player/src/components/PlaylistCover/index.tsx
@@ -35,14 +35,23 @@ export const PlaylistCover: FC<
 
 	useEffect(() => {
 		if (playlist?.coverPath) {
-			setPlaylistImgs([convertFileSrc(playlist.coverPath)]);
+			setPlaylistImgs([
+				playlist.coverPath.startsWith("http://") || playlist.coverPath.startsWith("https://")
+					? playlist.coverPath
+					: convertFileSrc(playlist.coverPath)
+			]);
 			return;
 		}
 		if (songs && songs.length > 0) {
 			const imgs = songs
 				.slice(0, 4)
 				// biome-ignore lint/style/noNonNullAssertion: filter() 检查了 coverPath 的存在
-				.map((s) => convertFileSrc(s.coverPath!));
+				.map((s) => {
+					const path = s.coverPath!;
+					return path.startsWith("http://") || path.startsWith("https://")
+						? path
+						: convertFileSrc(path);
+				});
 			setPlaylistImgs(imgs);
 		} else {
 			setPlaylistImgs([]);

--- a/packages/player/src/utils/use-song-cover.ts
+++ b/packages/player/src/utils/use-song-cover.ts
@@ -27,7 +27,11 @@ export const useSongCover = (song?: Song) => {
 		// 3. 从 dexie 迁移导入时，使用前端的 mime type
 		// 所以可以确保封面路径总是 jpg 或 mp4 文件，方便判断封面是图片或者视频
 		if (!song.coverPath.endsWith(".mp4")) {
-			setSongImgUrl(convertFileSrc(song.coverPath));
+			if (song.coverPath.startsWith("http://") || song.coverPath.startsWith("https://")) {
+				setSongImgUrl(song.coverPath);
+			} else {
+				setSongImgUrl(convertFileSrc(song.coverPath));
+			}
 			return;
 		}
 
@@ -39,7 +43,9 @@ export const useSongCover = (song?: Song) => {
 
 		setSongImgUrl("");
 		const coverPath = song.coverPath;
-		const videoSrc = convertFileSrc(coverPath);
+		const videoSrc = coverPath.startsWith("http://") || coverPath.startsWith("https://")
+			? coverPath
+			: convertFileSrc(coverPath);
 		getVideoThumbnail(videoSrc)
 			.then((blob) => {
 				const url = URL.createObjectURL(blob);


### PR DESCRIPTION
### 💡 变更背景

此前播放器核心及前端封面组件仅支持本地文件路径。本 PR 扩展了对 HTTP/HTTPS 网络资源（网络音频流及网络封面）的支持。



### 🛠️ 修改内容

- **后端 (Rust `player-core`)**:

  - 引入了 `reqwest` 依赖。

  - 在播放音频时，若音频路径为 `http://` 或 `https://` 开头，则使用 `reqwest` 异步下载并读取为内存字节流进行播放；非网络链接仍按本地文件打开。

- **前端 (TSX `player`)**:

  - 适配了网络封面路径。在 `LocalMusicContext`、`NowPlaylistCard`、`PlaylistCover` 及 `useSongCover` 钩子中，如果是 HTTP/HTTPS 网络封面链接则直接渲染，不再使用 `convertFileSrc` 转换。

