### PR TITLE
feat: 添加歌词页鼠标指针自动隐藏功能

### DIFF
--- a/packages/player/src/components/AMLLWrapper/index.module.css
+++ b/packages/player/src/components/AMLLWrapper/index.module.css
@@ -25,3 +25,10 @@
 		border-radius: 0 0 0 0;
 	}
 }
+
+.cursorHiddenOverlay {
+	position: absolute;
+	inset: 0;
+	cursor: none;
+	z-index: 9999;
+}

--- a/packages/player/src/components/AMLLWrapper/index.tsx
+++ b/packages/player/src/components/AMLLWrapper/index.tsx
@@ -7,6 +7,7 @@ import { ContextMenu } from "@radix-ui/themes";
 import classnames from "classnames";
 import { useAtomValue, useSetAtom } from "jotai";
 import { type FC, useEffect, useLayoutEffect } from "react";
+import { useCursorAutoHide } from "../../utils/useCursorAutoHide.ts";
 import { useTitlebarAutoHide } from "../../utils/useTitlebarAutoHide.ts";
 import { AMLLContextMenuContent } from "../AMLLContextMenu/index.tsx";
 import { AudioQualityDialog } from "../AudioQualityDialog/index.tsx";
@@ -22,6 +23,7 @@ export const AMLLWrapper: FC = () => {
 	const setLyricPageOpened = useSetAtom(isLyricPageOpenedAtom);
 
 	useTitlebarAutoHide(isLyricPageOpened);
+	const cursorHidden = useCursorAutoHide(isLyricPageOpened);
 
 	useLayoutEffect(() => {
 		if (isLyricPageOpened) {
@@ -65,6 +67,9 @@ export const AMLLWrapper: FC = () => {
 							style={{ width: "100%", height: "100%" }}
 							bottomLineSlot={<BottomLyricInfo />}
 						/>
+						{cursorHidden && (
+							<div className={styles.cursorHiddenOverlay} />
+						)}
 					</div>
 				</ContextMenu.Trigger>
 				<AMLLContextMenuContent />

--- a/packages/player/src/utils/useCursorAutoHide.ts
+++ b/packages/player/src/utils/useCursorAutoHide.ts
@@ -1,0 +1,31 @@
+import { useEffect, useState } from "react";
+
+export function useCursorAutoHide(enabled: boolean, delay = 1200) {
+	const [hidden, setHidden] = useState(false);
+
+	useEffect(() => {
+		if (!enabled) {
+			setHidden(false);
+			return;
+		}
+
+		let timerId: ReturnType<typeof setTimeout>;
+		const bump = () => {
+			clearTimeout(timerId);
+			setHidden(false);
+			timerId = setTimeout(() => setHidden(true), delay);
+		};
+		bump();
+
+		window.addEventListener("mousemove", bump);
+		window.addEventListener("mousedown", bump);
+		return () => {
+			clearTimeout(timerId);
+			window.removeEventListener("mousemove", bump);
+			window.removeEventListener("mousedown", bump);
+			setHidden(false);
+		};
+	}, [enabled, delay]);
+
+	return hidden;
+}


### PR DESCRIPTION
**实现歌词页鼠标自动隐藏功能**

关联issue：https://github.com/amll-dev/amll-player/issues/11

- 进入歌词全屏页后，鼠标静止1.2秒自动隐藏指针
- 鼠标移动或点击时立即恢复指针显示