### PR TITLE
fix(player): NVIDIA Wayland explicit sync 与动画状态更新优化

### DIFF
--- a/packages/player-core/src/player.rs
+++ b/packages/player-core/src/player.rs
@@ -246,6 +246,7 @@ impl AudioPlayer {
 
     pub async fn run(mut self) {
         let mut check_end_interval = tokio::time::interval(Duration::from_millis(50));
+        let mut media_controls_events_open = true;
 
         loop {
             tokio::select! {
@@ -258,11 +259,15 @@ impl AudioPlayer {
                         }
                     } else { break; }
                 },
-                msg = self.npc_event_rx.recv() => {
+                msg = self.npc_event_rx.recv(), if media_controls_events_open => {
                     if let Some(event) = msg {
                         self.media_manager
                             .handle_event(event, &self.handler(), &self.evt_sender)
                             .await;
+                    } else {
+                        // A failed media-controls initialization closes the channel.
+                        // Stop polling it or this select loop remains continuously ready.
+                        media_controls_events_open = false;
                     }
                 },
                 _ = check_end_interval.tick() => {

--- a/packages/player/src-tauri/src/lib.rs
+++ b/packages/player/src-tauri/src/lib.rs
@@ -17,6 +17,8 @@ use crate::server::AMLLWebSocketServerWrapper;
 
 mod db;
 mod db_events;
+#[cfg(target_os = "linux")]
+mod linux_graphics;
 mod logging;
 mod music_info;
 mod player;
@@ -189,6 +191,9 @@ fn handle_window_event(_window: &tauri::Window, _event: &tauri::WindowEvent) {
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    #[cfg(target_os = "linux")]
+    linux_graphics::configure_nvidia_wayland();
+
     // Install ring as the default crypto provider for rustls, because multiple providers
     // (aws-lc-rs and ring) might be enabled in our dependency tree and rustls demands one to be explicitly chosen.
     #[cfg(target_os = "android")]

--- a/packages/player/src-tauri/src/linux_graphics.rs
+++ b/packages/player/src-tauri/src/linux_graphics.rs
@@ -1,0 +1,16 @@
+use std::{env, path::Path};
+
+/// NVIDIA's explicit-sync path can fail when WebKitGTK creates a native
+/// Wayland surface. Disable it before GTK/WebKit initialization on affected
+/// Linux sessions; an existing user value always wins.
+pub(crate) fn configure_nvidia_wayland() {
+    if env::var_os("WAYLAND_DISPLAY").is_none()
+        || env::var_os("__NV_DISABLE_EXPLICIT_SYNC").is_some()
+        || !Path::new("/dev/nvidiactl").exists()
+    {
+        return;
+    }
+
+    // SAFETY: called before Tauri initializes GTK or starts worker threads.
+    unsafe { env::set_var("__NV_DISABLE_EXPLICIT_SYNC", "1") };
+}

--- a/packages/player/src/components/LocalMusicContext/index.tsx
+++ b/packages/player/src/components/LocalMusicContext/index.tsx
@@ -60,7 +60,7 @@ import { useDbQuery } from "../../utils/use-db-query.ts";
 export const FFTToLowPassContext: FC = () => {
 	const store = useStore();
 	const fftDataRange = useAtomValue(fftDataRangeAtom);
-	// const isLyricPageOpened = useAtomValue(isLyricPageOpenedAtom);
+	const isLyricPageOpened = useAtomValue(isLyricPageOpenedAtom);
 
 	useEffect(() => {
 		emitAudioThread("setFFTRange", {
@@ -70,7 +70,9 @@ export const FFTToLowPassContext: FC = () => {
 	}, [fftDataRange]);
 
 	useEffect(() => {
-		// if (!isLyricPageOpened) return;
+		// The low-frequency value only drives the full-screen lyric background.
+		// Keep this loop stopped while that view is hidden.
+		if (!isLyricPageOpened) return;
 		let rafId: number;
 		let curValue = 1;
 		let lt = 0;
@@ -134,8 +136,7 @@ export const FFTToLowPassContext: FC = () => {
 		return () => {
 			cancelAnimationFrame(rafId);
 		};
-	}, [store]);
-	// }, [store, isLyricPageOpened]);
+	}, [store, isLyricPageOpened]);
 
 	return null;
 };
@@ -362,7 +363,12 @@ export const LocalMusicContext: FC = () => {
 				const duration = store.get(musicDurationAtom) / 1000;
 				const clampedPos = Math.min(newPos, duration || 0);
 
-				store.set(musicPlayingPositionAtom, (clampedPos * 1000) | 0);
+				lastSyncRef.current.position = clampedPos;
+				lastSyncRef.current.timestamp = now;
+				const nextPosition = (clampedPos * 1000) | 0;
+				if (nextPosition !== store.get(musicPlayingPositionAtom)) {
+					store.set(musicPlayingPositionAtom, nextPosition);
+				}
 			} else {
 				const currentUIPosition = store.get(musicPlayingPositionAtom) / 1000;
 				lastSyncRef.current.position = currentUIPosition;

--- a/packages/player/vite.config.ts
+++ b/packages/player/vite.config.ts
@@ -86,7 +86,12 @@ const GitMetadataPlugin = (): Plugin => {
 };
 
 // https://vitejs.dev/config/
-export default defineConfig({
+export default defineConfig(({ command }) => {
+	// Vite's dev server needs the development React Refresh preamble even when
+	// the parent process exports NODE_ENV=production.
+	if (command === "serve") process.env.NODE_ENV = "development";
+
+	return {
 	build: {
 		chunkSizeWarningLimit: 2000,
 		rolldownOptions: {
@@ -150,4 +155,5 @@ export default defineConfig({
 	// 3. to make use of `TAURI_DEBUG` and other env variables
 	// https://tauri.studio/v1/api/config#buildconfig.beforedevcommand
 	envPrefix: ["VITE_", "TAURI_"],
+	};
 });


### PR DESCRIPTION
### 改动内容

**1. 配置 NVIDIA Wayland explicit sync**（`808e7df8`）
- 在 Wayland 会话且检测到 NVIDIA 设备时，于 GTK/WebKit 初始化前设置 `__NV_DISABLE_EXPLICIT_SYNC=1`，避免 WebKitGTK 创建原生 Wayland 表面时 explicit sync 路径失败（用户已有的环境变量优先）。
- 顺带修复播放器事件循环：媒体控件初始化失败后通道会关闭，之前会使 `select!` 持续就绪并空转；现在该分支会被正确停用。

**2. 减少不必要的动画状态更新**（`80f33101`）
- 低频音量计算循环（其结果只被全屏歌词页的流体背景使用）改回「仅在歌词页打开时运行」，避免歌词页关闭时每帧空算并写入 atom。
- 播放进度更新不再每帧无条件写入 atom：每帧推进同步基准，并且仅在取整后的毫秒值真正变化时才写入。

### 验证

本机 KDE Wayland（KWin 6.7 / AMD Radeon 880M / WebKitGTK 4.1）实测：歌词页关闭时低频循环不再运行；播放中进度 atom 的写入按上述条件收敛。
